### PR TITLE
shared_config: reuse the shared service_user_agent helper

### DIFF
--- a/src/shared_config/http.rs
+++ b/src/shared_config/http.rs
@@ -1,10 +1,7 @@
 //! Shared HTTP client configuration and factory for Janitor services
 
+use crate::utils::service_user_agent;
 use base64::prelude::*;
-
-fn service_user_agent(service_name: &str) -> String {
-    format!("{}/{}", service_name, env!("CARGO_PKG_VERSION"))
-}
 use reqwest::{Client, ClientBuilder};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;


### PR DESCRIPTION
The HTTP client factory defined its own service_user_agent that duplicated the one in utils. Use the shared helper, which also gives these clients the same "janitor-<service>" user-agent prefix the rest of the codebase already sends.