### PR TITLE
Makefile: mark build-all/docker-all/push-all as .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ push-%:
 	buildah push ghcr.io/jelmer/janitor/$*:$(DOCKER_TAG)
 	buildah push ghcr.io/jelmer/janitor/$*:$(SHA)
 
+.PHONY: docker-all build-all push-all
+
 docker-all: $(DOCKER_TARGETS)
 
 build-all: $(BUILD_TARGETS)


### PR DESCRIPTION
Without a recipe of their own, these targets matched the `build-%`/`docker-%`/`push-%` pattern rules with stem "all", attempting to build from a nonexistent `Dockerfile_all` and failing with `Error 125` even when every real target succeeded.

Declaring them `.PHONY` stops `make` from falling back to the pattern rule for them.

```console
$ make -n build-all docker-all push-all | grep -c Dockerfile_all
0
$ make -n build-all docker-all push-all >/dev/null; echo "exit: $?"
exit: 0
```
