### PR TITLE
janitor: drop URLopener, removed from urllib.request

### DIFF
--- a/py/janitor/__init__.py
+++ b/py/janitor/__init__.py
@@ -18,7 +18,7 @@
 
 import shlex
 from pathlib import Path
-from urllib.request import URLopener, build_opener, install_opener
+from urllib.request import build_opener, install_opener
 
 from breezy.transport import http as _mod_http
 from breezy.transport.http import urllib as _mod_urllib
@@ -43,7 +43,6 @@ def get_debian_schema() -> str:
 def set_user_agent(user_agent):
     _mod_http.default_user_agent = lambda: user_agent
     _mod_urllib.AbstractHTTPHandler._default_headers["User-agent"] = user_agent
-    URLopener.version = user_agent
     opener = build_opener()
     opener.addheaders = [("User-agent", user_agent)]
     install_opener(opener)


### PR DESCRIPTION
`URLopener.version` was set in `set_user_agent()` but `URLopener` itself has been removed from `urllib.request` in Python 3.14 (deprecated since 3.3, finally removed - see [python/cpython#84850](https://github.com/python/cpython/issues/84850)). This crashes `import janitor` before any service-specific code runs. `build_opener` and `install_opener` right below it already do the real work and are still valid, so `URLopener` served no purpose beyond that one dead attribute set.

```console
$ podman run --rm --entrypoint python3 runner:latest -c "import janitor"
  File "/usr/local/lib/python3.14/dist-packages/janitor/__init__.py", line 21, in <module>
    from urllib.request import URLopener, build_opener, install_opener
ImportError: cannot import name 'URLopener' from 'urllib.request'

$ podman run --rm --entrypoint python3 runner:patched -c "import janitor; print('import janitor OK')"
import janitor OK
```

Breaks every service that imports the `janitor` package on a fresh build (`runner`, `site`, `git_store`, `bzr_store`, `archive`, and `auto_upload`).
