### PR TITLE
pyproject: point janitor-bzr-store at janitor.bzr_store, not git_store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ s3 = [
 [project.scripts]
 janitor-auto-upload = "janitor.debian.auto_upload:main"
 janitor-archive = "janitor.debian.archive:main"
-janitor-bzr-store = "janitor.git_store:main"
+janitor-bzr-store = "janitor.bzr_store:main"
 janitor-differ = "janitor.differ:main"
 janitor-git-store = "janitor.git_store:main"
 #janitor-mail-filter == rust


### PR DESCRIPTION
`janitor-bzr-store` and `janitor-git-store` both pointed at `janitor.git_store:main`. `bzr_store.py` has its own working `main()`/`main_async()` with the correct routes/ports for Bazaar hosting, but nothing wired it up - the bzr-store container silently served the git protocol on the bzr ports instead.

```console
$ podman run --rm --entrypoint janitor-bzr-store bzr_store:latest --help
usage: janitor.git_store [-h] [--port PORT] [--public-port PUBLIC_PORT]
                         [--listen-address LISTEN_ADDRESS] [--config CONFIG]
                         [--vcs-path VCS_PATH]

$ podman run --rm --entrypoint janitor-bzr-store bzr_store:patched --help
usage: janitor.bzr_store [-h] [--port PORT] [--public-port PUBLIC_PORT]
                         [--listen-address LISTEN_ADDRESS] [--config CONFIG]
                         [--vcs-path VCS_PATH]
```
