### PR TITLE
Dockerfile_site: install libjs-chart.js

### DIFF
--- a/Dockerfile_site
+++ b/Dockerfile_site
@@ -22,6 +22,7 @@ RUN apt-get update --yes \
         pkg-config \
         protobuf-compiler \
        ## Extra packages
+        libjs-chart.js \
         libjs-jquery-datatables \
         python3-gpg \
         python3-pip \


### PR DESCRIPTION
`layout.html` references `/_static/chart.js`, served by `simple.py` from `/usr/share/javascript/chart.js/Chart.js` - the standard Debian JS-vendoring path. Nothing installs [`libjs-chart.js`](https://tracker.debian.org/pkg/node-chart.js), the package that provides it, so every page with a chart (Result Codes, Failure Stages) 404s on it and the pie chart never renders, while its 600px-tall container still reserves the space.

```console
$ podman run --rm --entrypoint sh site:latest -c 'ls /usr/share/javascript/chart.js/Chart.js'
ls: cannot access '/usr/share/javascript/chart.js/Chart.js': No such file or directory

$ podman run --rm --entrypoint sh site:patched -c 'ls -la /usr/share/javascript/chart.js/Chart.js'
lrwxrwxrwx 1 root root 8 Aug 13  2023 /usr/share/javascript/chart.js/Chart.js -> chart.js
```
