### PR TITLE
Dockerfile_worker: install ca-certificates in the final image, not just build stage

### DIFF
--- a/Dockerfile_worker
+++ b/Dockerfile_worker
@@ -36,6 +36,7 @@ RUN apt-get update --yes \
         iproute2 \
  && apt-get upgrade --yes \
  && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
         libpython3-dev \
         python3-breezy \
         dpkg-dev \


### PR DESCRIPTION
The build stage installs `ca-certificates` (needed to fetch cargo deps over HTTPS), but the final runtime stage never does - only `libpython3-dev`, `python3-breezy` and `dpkg-dev` get installed there. The compiled binary is copied over via `COPY --from=build`, but a system package's cert bundle isn't something that travels with it.

Every outbound HTTPS connection the worker makes fails as a result.

```console
$ podman run --rm --entrypoint janitor-worker worker:latest --port=9821 --listen-address=0.0.0.0 --base-url http://localhost:9919/runner/ --loop
[INFO  janitor_worker] listening on 0.0.0.0:9821

thread 'tokio-rt-worker' panicked at worker/src/client.rs:223:37:
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

This kills the worker's polling loop silently - the container keeps running (the listen socket is still up, so a naive health check passes), but it can never actually pick up or process any queued work. After adding `ca-certificates` to the final stage, the same command authenticates and receives real assignments correctly.
