### PR TITLE
janitor: fall back to a default when user_agent is not configured

### DIFF
--- a/py/janitor/__init__.py
+++ b/py/janitor/__init__.py
@@ -41,6 +41,8 @@ def get_debian_schema() -> str:
 
 
 def set_user_agent(user_agent):
+    if user_agent is None:
+        user_agent = f"janitor/{version_string}"
     _mod_http.default_user_agent = lambda: user_agent
     _mod_urllib.AbstractHTTPHandler._default_headers["User-agent"] = user_agent
     URLopener.version = user_agent


### PR DESCRIPTION
`user_agent` is optional in `config.proto` and unset in both our config
and the shipped `janitor.conf.example`. Unset comes through as `None`,
and `set_user_agent(None)` (`janitor/__init__.py`) puts that `None`
into the headers used for outgoing requests, including breezy's GitHub
API calls.

Reproduced directly against `http.client`, which is what everything in
this chain eventually calls into:

```
$ python3 -c '
import http.client
conn = http.client.HTTPConnection("example.invalid", 80, timeout=3)
conn.request("GET", "/", headers={"User-agent": None})
'
Traceback (most recent call last):
  ...
TypeError: expected string or bytes-like object, got NoneType
```
