### PR TITLE
Dockerfile_worker: use tini as PID 1 so orphaned subprocess zombies get reaped

### DIFF
--- a/Dockerfile_worker
+++ b/Dockerfile_worker
@@ -34,6 +34,7 @@ RUN apt-get update --yes \
  && apt-get install --yes --no-install-recommends \
         auto-apt-proxy \
         iproute2 \
+        tini-static \
  && apt-get upgrade --yes \
  && apt-get satisfy --yes --no-install-recommends \
         libpython3-dev \
@@ -49,4 +50,5 @@ ENV AUTOPKGTEST=/usr/local/bin/autopkgtest-wrapper
 
 EXPOSE 9821
 
-ENTRYPOINT ["janitor-worker", "--port=9821", "--listen-address=0.0.0.0"]
+# tini-static reaps zombies that janitor-worker, running as PID 1, would otherwise leave.
+ENTRYPOINT ["tini-static", "--", "janitor-worker", "--port=9821", "--listen-address=0.0.0.0"]


### PR DESCRIPTION
`janitor-worker` runs as `PID 1` in its container with no init.
`auto-apt-proxy` spawns short-lived `[http]` helpers on every `apt-get`
during dependency resolution. Once one of those is reparented to `PID 1`
(its own immediate parent exits first), nothing reaps it: the worker
only waits on processes it spawns directly.

```
$ podman run -d --name sigcheck --entrypoint janitor-worker ghcr.io/jelmer/janitor/worker:latest --base-url http://localhost:1/ --output-directory /tmp
$ podman exec sigcheck cat /proc/1/status | grep -iE "sigign|sigcgt"
SigIgn:	0000000000001000
SigCgt:	0000000100000442
```

Neither mask has bit 0x10000 set (`SIGCHLD` is signal 17). The kernel
only auto-reaps a reparented child if `PID 1` has `SIGCHLD` set to
`SIG_IGN`; `janitor-worker` does neither that nor an explicit
`waitpid()` loop over arbitrary children, so anything reparented to it
just accumulates as a zombie forever.

A zombie holds its PID until reaped, and PID space is finite
(`/proc/sys/kernel/pid_max`). Enough of them and `fork()` starts
failing for new processes in the container - including the worker's
own `apt-get`/`breezy`/`sbuild` subprocesses, the exact things it
needs to do its job.

`tini-static` as `PID 1` reaps them - see https://github.com/krallin/tini.