### PR TITLE
gitignore: add /janitor.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _build/*
 *~
 site/_build
 state.db
+/janitor.conf
 site/history.rst
 build.log
 debian_janitor.egg-info/


### PR DESCRIPTION
`docs/Dockerfiles_.md`'s run examples mount the repo root to
`/mnt/janitor` and point `--config` at `janitor.conf.example` directly.
A real deployment can't actually run against the example's placeholder
values, so it ends up with a real, credential-filled config at that
same repo-root path - the natural sibling name is `janitor.conf`, and
nothing in `.gitignore` accounts for it. A real config there - database
credentials, an OAuth client secret - is one `git add -A` away from
being committed. `janitor.conf.example` stays tracked as the sample.

```console
$ echo "fake secret" > janitor.conf && git status --porcelain janitor.conf
$ git check-ignore -v janitor.conf
.gitignore:14:/janitor.conf	janitor.conf
```