### PR TITLE
worker: sleep 5s on an empty queue instead of busy-looping

### DIFF
--- a/worker/src/bin/worker.rs
+++ b/worker/src/bin/worker.rs
@@ -182,6 +182,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 Err(janitor_worker::SingleItemError::EmptyQueue) => {
                     log::info!("queue is empty");
+                    // avoid busy-looping and re-spawning dpkg-architecture every iteration
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     0
                 }
                 Ok(_) => 0,


### PR DESCRIPTION
The main loop in `worker.rs` immediately re-called `process_single_item()` on `SingleItemError::EmptyQueue` with no delay. Each call re-invokes `get_build_arch()`, which shells out to `dpkg-architecture`. An idle worker (empty queue, the normal steady state between jobs) was spawning a fresh `dpkg-architecture` process and re-POSTing to the runner assignment endpoint as fast as the CPU/network allowed.

## Before

Checked for a live `dpkg-architecture` process every 0.1s for 5s, on an idle worker:

```
$ for i in $(seq 1 50); do
    ps -eo comm | grep -c dpkg-archite
    sleep 0.1
  done | awk "{s+=\$1} END {print s, \"hits / 50 checks\"}"
45 hits / 50 checks
```

Both workers had been stuck like this for 25+ minutes (`ps -o pid,ppid,etime,comm` showed fresh `dpkg-architecture` PIDs spawning continuously, parent PID = the worker binary itself).

## After

After the fix, checked once a second for 15s:

```
$ for i in $(seq 1 15); do
    ps -eo comm | grep -c dpkg-archite
    sleep 1
  done | awk "{s+=\$1} END {print s, \"hits / 15 checks\"}"
0 hits / 15 checks
```

```
$ journalctl --user -u janitor-worker --since "-20 seconds" -o short-precise | grep "queue is empty"
Aug 13 13:59:33.022686 ... INFO janitor_worker] queue is empty
Aug 13 13:59:38.043836 ... INFO janitor_worker] queue is empty
Aug 13 13:59:43.065457 ... INFO janitor_worker] queue is empty
Aug 13 13:59:48.087320 ... INFO janitor_worker] queue is empty
```

~5.02s apart, matching the `Duration::from_secs(5)` sleep.

