### PR TITLE
Dockerfile_worker: install brz-debian, the plugin providing breezy.plugins.debian

### DIFF
--- a/Dockerfile_worker
+++ b/Dockerfile_worker
@@ -38,6 +38,7 @@ RUN apt-get update --yes \
  && apt-get satisfy --yes --no-install-recommends \
         libpython3-dev \
         python3-breezy \
+        brz-debian \
         dpkg-dev \
  && apt-get clean
 


### PR DESCRIPTION
Any debian-campaign run hits `DependencyNotPresent("breezy.plugins.debian", "Install the brz-debian plugin")` inside `run_worker()`, which panics inside `tokio::spawn_blocking`. The outer `.await.unwrap()` on the resulting `JoinError` re-panics in the async context, killing the worker's polling loop silently - the container stays up since axum keeps serving `/health` etc, but the loop never runs again until something restarts it.

`python3-breezy` alone does not provide `breezy.plugins.debian` - it is a separate plugin package, `brz-debian`, confirmed present and current in the standard apt repos and not otherwise installed by `Dockerfile_worker`. With it added:

```
$ podman exec <worker> dpkg -l brz-debian
ii  brz-debian     2.8.81       all          breezy plugin for Debian package management
$ podman exec <worker> python3 -c "import breezy.plugins.debian; print(\"import OK\")"
import OK
```
