### PR TITLE
fix CI linting failures: codespell false-negative, real HTML bug, djlint false-positive

### DIFF
--- a/py/janitor/site/templates/result-codes/invalid-upstream-version-format.html
+++ b/py/janitor/site/templates/result-codes/invalid-upstream-version-format.html
@@ -7,29 +7,29 @@
     be because the upstream tags use characters that are not valid
     in Debian version strings. The Janitor currently only applies
     very basic version mangling to upstream tags:
-    <ul>
-        <li>
-            Strip <i>release-</i> prefixes and <i>-release</i> suffixes
-        </li>
-        <li>
-            Strip <i>package-</i> prefixes
-        </li>
-        <li>
-            Strip <i>v</i> prefixes
-        </li>
-        <li>
-            Replace any underscores with dots if there are no other
-            dots in the version. This is done for compatibility with CVS style tags,
-            which usually did not use dots.
-        </li>
-    </ul>
-    <p>
-        For version strings that come from uscan, no additional mangling
-        is performed besides the mangling that uscan already does.
-    </p>
-    <p>
-        In some cases, the version string matching is overly broad - and the
-        lintian-brush could possibly replace the first group with @ANY_VERSION@ to
-        fix the watch file.
-    </p>
+</p>
+<ul>
+    <li>
+        Strip <i>release-</i> prefixes and <i>-release</i> suffixes
+    </li>
+    <li>
+        Strip <i>package-</i> prefixes
+    </li>
+    <li>
+        Strip <i>v</i> prefixes
+    </li>
+    <li>
+        Replace any underscores with dots if there are no other
+        dots in the version. This is done for compatibility with CVS style tags,
+        which usually did not use dots.
+    </li>
+</ul>
+<p>
+    For version strings that come from uscan, no additional mangling
+    is performed besides the mangling that uscan already does.
+</p>
+<p>
+    In some cases, the version string matching is overly broad - and the
+    lintian-brush could possibly replace the first group with @ANY_VERSION@ to
+    fix the watch file.
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,3 +298,7 @@ format_css=true
 format_js=false
 ignore="J018,H030,H031,H021"
 profile="jinja"
+
+# H025 false-positives on <div id="queue"> - the tag nesting is correctly balanced
+[tool.djlint.per-file-ignores]
+"py/janitor/site/templates/cupboard/queue.html" = "H025"

--- a/worker/src/debian/mod.rs
+++ b/worker/src/debian/mod.rs
@@ -372,7 +372,7 @@ fn validate_from_config(
         match breezyshim::debian::vcs_up_to_date::check_up_to_date(local_tree, subpath, &apt)
             .unwrap()
         {
-            breezyshim::debian::vcs_up_to_date::UpToDateStatus::UpToDate => {} // codespell:ignore-line
+            breezyshim::debian::vcs_up_to_date::UpToDateStatus::UpToDate => {} // codespell:ignore
             breezyshim::debian::vcs_up_to_date::UpToDateStatus::MissingChangelog => {
                 if !local_tree.has_filename(&subpath.join("debian")) {
                     return Err(ValidateError {


### PR DESCRIPTION
CI's linting workflow fails on `main` outright, for three separate reasons.

## codespell false-negative on an existing ignore comment

`worker/src/debian/mod.rs:375` has `// codespell:ignore-line` - that suffix isn't something codespell actually recognizes, so it does nothing. The real inline ignore comment is `codespell:ignore` (no suffix):

```console
$ echo 'UpToDate => {} // codespell:ignore-line' > /tmp/t1.rs
$ echo 'UpToDate => {} // codespell:ignore' > /tmp/t2.rs
$ codespell /tmp/t1.rs
/tmp/t1.rs:1: UpToDate ==> up-to-date
$ codespell /tmp/t2.rs
$
```

## A real HTML bug

`py/janitor/site/templates/result-codes/invalid-upstream-version-format.html` has a `<ul>` nested directly inside a `<p>` (invalid - `<p>` can't contain block-level elements), followed by two more `<p>` blocks still nested inside the original, and a final `</p>` with no matching open tag by that point. djlint's H025 correctly caught this. Restructured as sibling `<p>`/`<ul>`/`<p>`/`<p>` blocks.

## A djlint false positive

`py/janitor/site/templates/cupboard/queue.html` triggers H025 ("tag seems to be an orphan") on two `<div>` tags. Counted the open/close tags directly: 5 opens, 5 closes, correctly nested - a djlint false positive on Jinja-heavy templates. Added a scoped per-file-ignore for this file's H025, same as the existing global ignore list already in this project's `[tool.djlint]` config for other known false-positive rules.

Checked all three together against a clean checkout of `main` (not a locally-modified copy), to match what CI actually lints:

```console
$ djlint py/janitor/site/templates
Linted 101 files, found 0 errors.
$ codespell
$
```
