### PR TITLE
worker: remove unused WorkingTree::clone() call in the build-suffix path

### DIFF
--- a/worker/src/debian/build.rs
+++ b/worker/src/debian/build.rs
@@ -92,13 +92,6 @@ pub(crate) fn build(
 
         let result: Result<BuildOnceResult, IterateBuildError> =
             if let Some(suffix) = config.build_suffix.as_ref() {
-                let cloned_tree = breezyshim::tree::WorkingTree::clone(local_tree, subpath, None)
-                    .map_err(|e| BuildFailure {
-                    code: "clone-tree".to_string(),
-                    description: format!("Error cloning tree: {}", e),
-                    stage: vec!["build".to_string()],
-                    details: None,
-                })?;
                 let packaging_context = ognibuild::debian::context::DebianPackagingContext::new(
                     Clone::clone(local_tree),
                     subpath,


### PR DESCRIPTION
The `build_suffix` build path clones the working tree and never uses the clone, but the clone can still fail the whole build.

`worker/src/debian/build.rs`'s `build()` function, in the branch taken when `config.build_suffix` is set, calls `breezyshim::tree::WorkingTree::clone(local_tree, subpath, None)` and stores the result in `cloned_tree`. Nothing below reads `cloned_tree` - `build_incrementally()` is called with `local_tree` directly, and the `packaging_context` a few lines down comes from a separate `Clone::clone(local_tree)` (a plain struct clone, unrelated to the working-tree clone above). The clone exists, does nothing, and gets dropped.

Since the clone's `Result` is still handled with `?`, any real failure from it aborts the build immediately with a `"clone-tree"` `BuildFailure`, even though the build never depended on it. This traceback happened repeatedly, for every `build_suffix`-configured campaign:

```
Worker failed in ["build", "build"] (clone-tree): Error cloning tree: Error::Other(AttributeError: 'str' object has no attribute 'create_workingtree')
```
