### PR TITLE
vcs: fix bzr_location branch reading config.git_location by mistake

### DIFF
--- a/py/janitor/vcs.py
+++ b/py/janitor/vcs.py
@@ -110,12 +110,12 @@ def get_vcs_managers_from_config(config) -> dict[str, VcsManager]:  # type: igno
                 config.git_location,
             )
     if config.bzr_location:
-        parsed = urlutils.URL.from_string(config.git_location)
+        parsed = urlutils.URL.from_string(config.bzr_location)
         if parsed.scheme in ("", "file"):
             ret["bzr"] = LocalBzrVcsManager(parsed.path)
         else:
             ret["bzr"] = RemoteBzrVcsManager(
-                config.git_location,
+                config.bzr_location,
             )
     return ret
 


### PR DESCRIPTION
## `bzr_location` branch reads `git_location` instead

`get_vcs_managers_from_config()`'s `if config.bzr_location:` block reads and passes `config.git_location`, not `config.bzr_location`, in both the URL-scheme check and the `RemoteBzrVcsManager` construction (`py/janitor/vcs.py`). Any config with `bzr_location` set but `git_location` unset builds against the wrong (missing) value:

```
>>> get_vcs_managers_from_config(FakeConfig(git_location=None, bzr_location="http://localhost:9929"))
Traceback (most recent call last):
  ...
breezy.urlutils.InvalidURL: Invalid url supplied to transport: "None"
```

Fixed by reading `config.bzr_location` in both spots, matching the `git_location` block directly above it.
